### PR TITLE
Adding a security group ingress rule on the worker node to access metrics server via the kube-api

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -228,6 +228,15 @@ module "eks" {
   enable_irsa                 = true
   create_cloudwatch_log_group = false
   node_security_group_additional_rules = {
+
+    ingress_cluster_metricserver = {
+      description                   = "Cluster to node 4443 (Metrics Server)"
+      protocol                      = "tcp"
+      from_port                     = 4443
+      to_port                       = 4443
+      type                          = "ingress"
+      source_cluster_security_group = true
+    }
     ingress_allow_access_from_control_plane = {
       type                          = "ingress"
       protocol                      = "tcp"


### PR DESCRIPTION
https://github.com/ubc/jupyterhub/issues/53

 The metrics server that was throwing the following message when trying to do kubectl top nodes / kubectl top pods
```
couldn't get resource list for metrics.k8s.io/v1beta1: the server is currently unable to handle the request
couldn't get resource list for metrics.k8s.io/v1beta1: the server is currently unable to handle the request
couldn't get resource list for metrics.k8s.io/v1beta1: the server is currently unable to handle the request
```
Had to allow a port on the node security group

```
    ingress_cluster_metricserver = {
      description                   = "Cluster to node 4443 (Metrics Server)"
      protocol                      = "tcp"
      from_port                     = 4443
      to_port                       = 4443
      type                          = "ingress"
      source_cluster_security_group = true
    }
```