### PR TITLE
enable dhcp_options to use custom domain for EKS EC2 node

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -198,6 +198,8 @@ module "vpc" {
   enable_nat_gateway   = true
   single_nat_gateway   = true
   enable_dns_hostnames = true
+  enable_dhcp_options  = true
+  dhcp_options_domain_name  = var.dhcp_options_domain_name
 
   tags = {
     "kubernetes.io/cluster/${local.cluster_name}" = "shared"

--- a/main.tf
+++ b/main.tf
@@ -198,8 +198,9 @@ module "vpc" {
   enable_nat_gateway   = true
   single_nat_gateway   = true
   enable_dns_hostnames = true
-  enable_dhcp_options  = true
-  dhcp_options_domain_name  = var.dhcp_options_domain_name
+  enable_dhcp_options              = var.enable_dhcp_options
+  dhcp_options_domain_name         = var.dhcp_options_domain_name
+  dhcp_options_domain_name_servers = var.dhcp_options_domain_name_servers 
 
   tags = {
     "kubernetes.io/cluster/${local.cluster_name}" = "shared"

--- a/variables.tf
+++ b/variables.tf
@@ -223,3 +223,21 @@ variable "enable_cluster_creator_admin_permissions" {
   description = "Indicates whether or not to add the cluster creator (the identity used by Terraform) as an administrator via access entry"
   default = true
 }
+
+variable "enable_dhcp_options" {
+  description = "Should be true if you want to specify a DHCP options set with a custom domain name, DNS servers, NTP servers, netbios servers, and/or netbios server type"
+  type        = bool
+  default     = true
+}
+
+variable "dhcp_options_domain_name" {
+  description = "Specifies DNS name for DHCP options set (requires enable_dhcp_options set to true)"
+  type        = string
+  default     = ""
+}
+
+variable "dhcp_options_domain_name_servers" {
+  description = "Specify a list of DNS server addresses for DHCP options set, default to AWS provided (requires enable_dhcp_options set to true)"
+  type        = list(string)
+  default     = ["AmazonProvidedDNS"]
+}


### PR DESCRIPTION
Hi @xcompass this change enable dhcp_options which allows us to use open.jupyter.ubc.ca as a EC2 hostname instead of the default value of region.compute.internal. 

I have tested this with provisioning to jupyter-open-trn. 

To enable this feature we will need to pass below variable by tfvars
dhcp_options_domain_name = "open.jupyter.ubc.ca"

