### PR TITLE
Version lock on efs, irsa, and lb registry

### DIFF
--- a/efs.tf
+++ b/efs.tf
@@ -1,5 +1,8 @@
 module "attach_efs_csi_role" {
   source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+# This section was added to lock the version of Terraform modules
+# terraform init -upgrade command downloads the newer versions of modules which sometimes break the configuraiton
+  version = "5.59.0"
 
   role_name             = "efs-csi-${local.cluster_name}"
   attach_efs_csi_policy = true

--- a/irsa.tf
+++ b/irsa.tf
@@ -1,5 +1,8 @@
 module "iam_assumable_role_admin" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+# This section was added to lock the version of Terraform modules
+# terraform init -upgrade command downloads the newer versions of modules which sometimes break the configuraiton
+  version = "5.59.0"
   create_role                   = true
   role_name                     = "cluster-autoscaler-${random_string.suffix.result}"
   provider_url                  = replace(module.eks.cluster_oidc_issuer_url, "https://", "")

--- a/lb.tf
+++ b/lb.tf
@@ -1,7 +1,9 @@
 # IAM role
 module "lb_role" {
   source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-
+# This section was added to lock the version of Terraform modules
+# terraform init -upgrade command downloads the newer versions of modules which sometimes break the configuraiton
+  version = "5.59.0"
   role_name                              = "${var.environment}_eks_lb"
   attach_load_balancer_controller_policy = true
 


### PR DESCRIPTION
The error was:
```╷
│ Error: Unreadable module subdirectory
│
│ The directory .terraform/modules/attach_efs_csi_role/modules/iam-role-for-service-accounts-eks does not exist. The target submodule
│ modules/iam-role-for-service-accounts-eks does not exist within the target module.
╵
╷
│ Error: Unreadable module subdirectory
│
│ The directory .terraform/modules/iam_assumable_role_admin/modules/iam-assumable-role-with-oidc does not exist. The target submodule modules/iam-assumable-role-with-oidc
│ does not exist within the target module.
╵
╷
│ Error: Unreadable module subdirectory
│
│ The directory .terraform/modules/lb_role/modules/iam-role-for-service-accounts-eks does not exist. The target submodule modules/iam-role-for-service-accounts-eks does
│ not exist within the target module.
```